### PR TITLE
initial iojs support

### DIFF
--- a/bin/nodenv-package-json-engine
+++ b/bin/nodenv-package-json-engine
@@ -20,16 +20,17 @@ should_find_in_package_json() {
 }
 
 version_from_package_json() {
-  local version_regex='"node":[ \t]*"([^"]*)"'
+  local version_regex='"(node|iojs)":[ \t]*"([^"]*)"'
   [[ `cat $PACKAGE_JSON_PATH` =~ $version_regex ]]
-  local version="${BASH_REMATCH[1]}"
+  local engine="${BASH_REMATCH[1]}"
+  local version="${BASH_REMATCH[2]}"
 
-  if [[ -n "$version" ]] ; then
+  if [ -n "$engine" ] && [ -n "$version" ]; then
     local simple_regex="^[0-9]+\.[0-9]+\.[0-9]+$"
     if ! [[ "$version" =~ $simple_regex ]]; then
-      version=$(curl --silent --get --data-urlencode "range=${version}" https://semver.herokuapp.com/node/resolve)
+      version=$(curl --silent --get --data-urlencode "range=${version}" https://semver.herokuapp.com/${engine}/resolve)
     fi
-    echo $version
+    echo "$engine-$version"
   fi
 }
 


### PR DESCRIPTION
This is more of a proof of concept, not quite ready to merge. (and only partially tested)

The version_regex is modified to match against `(node|iojs)`, and hits the appropriate semver.io URL. The matching version is then emitted as node-1.2.3 or iojs-1.2.3. This relies on a not-well-documented feature of nodenv. While iojs versions have always included the 'iojs-' prefix, node versions have omitted the prefix as a raw version number is implicitly 'node-'. However, as rbenv before it did with 'ruby-', nodenv accepts `node-1.2.3` as a valid version name and will still match installed versions _without_ the 'node-' prefix. https://github.com/OiNutter/nodenv/blob/master/libexec/nodenv-version-name#L25-L26

Except this doesn't actually work. The prefix munging logic (with/without `node-` prefix, with/without `v` prefix) only exists in the version-name script. (Typically executed by `nodenv version`) Since this plugin works via the `which` hook, it has to build the bin path itself, losing out on all the prefix munging goodness. (Until the previously mentioned PR for version-name/version-origin hooks gets merged into rbenv.)

So to make this PR work, we'll have to copypasta the prefix-munging code from version-name.

The other issue with this PR is with how `BASH_REMATCH` works. Since the regex hits against _either_ node or iojs, if a given package.json includes _both_, then this code will arbitrarily return the version for the first engine listed in package.json. I don't know how else we would want to handle this, so first-wins would work for me.

Anyway, good enough for a POC. Just don't merge this, yet.
