### PR TITLE
Resolves symlinks to get script dir

### DIFF
--- a/bin/nodenv-package-json-engine
+++ b/bin/nodenv-package-json-engine
@@ -8,22 +8,32 @@
 
 
 # Setup for relative includes
-# http://stackoverflow.com/a/12694189/407845
+# Adapted from
+# http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+# and http://stackoverflow.com/a/12694189/407845
+get_script_dir() {
+  # while $SOURCE is a symlink, resolve it
+  local dir
+  local src="${BASH_SOURCE[0]}"
 
-# while $SOURCE is a symlink, resolve it
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do
-	DIR="${SOURCE%/*}"
-	SOURCE="$( readlink "$SOURCE" )"
-	# If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
-	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
-done
+  while [ -h "$src" ]; do
+    dir="${src%/*}"
+    src="$( readlink "$src" )"
+    
+    # If $SOURCE was a relative symlink (so no "/" as prefix),
+    # need to resolve it relative to the symlink base directory
+    [[ $src != /* ]] && src="$dir/$src"
+  done
+  dir="${src%/*}"
+  
+  if [ -d "$dir" ]; then
+    echo "$dir"
+  else
+    echo "$PWD"
+  fi
+}
 
-# Setup for relative includes
-# http://stackoverflow.com/a/12694189/407845
-DIR="${SOURCE%/*}"
-[ -d "$DIR" ] || DIR="$PWD"
-
+DIR="$(get_script_dir)"
 
 SEMVER="$DIR/../node_modules/sh-semver/semver.sh"
 

--- a/bin/nodenv-package-json-engine
+++ b/bin/nodenv-package-json-engine
@@ -6,10 +6,24 @@
 # test the installed versions against that range and print the
 # greatest matching version.
 
+
 # Setup for relative includes
 # http://stackoverflow.com/a/12694189/407845
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+# while $SOURCE is a symlink, resolve it
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+	DIR="${SOURCE%/*}"
+	SOURCE="$( readlink "$SOURCE" )"
+	# If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
+	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+
+# Setup for relative includes
+# http://stackoverflow.com/a/12694189/407845
+DIR="${SOURCE%/*}"
+[ -d "$DIR" ] || DIR="$PWD"
+
 
 SEMVER="$DIR/../node_modules/sh-semver/semver.sh"
 

--- a/bin/nodenv-package-json-engine
+++ b/bin/nodenv-package-json-engine
@@ -7,35 +7,30 @@
 # greatest matching version.
 
 
-# Setup for relative includes
-# Adapted from
+# Setup for relative includes. Adapted from:
 # http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
-# and http://stackoverflow.com/a/12694189/407845
+# http://stackoverflow.com/a/12694189/407845
 get_script_dir() {
-  # while $SOURCE is a symlink, resolve it
   local dir
   local src="${BASH_SOURCE[0]}"
 
+  # while $src is a symlink, resolve it
   while [ -h "$src" ]; do
     dir="${src%/*}"
     src="$( readlink "$src" )"
-    
-    # If $SOURCE was a relative symlink (so no "/" as prefix),
+
+    # If $src was a relative symlink (so no "/" as prefix),
     # need to resolve it relative to the symlink base directory
     [[ $src != /* ]] && src="$dir/$src"
   done
   dir="${src%/*}"
-  
+
   if [ -d "$dir" ]; then
     echo "$dir"
   else
     echo "$PWD"
   fi
 }
-
-DIR="$(get_script_dir)"
-
-SEMVER="$DIR/../node_modules/sh-semver/semver.sh"
 
 find_package_json_path() {
   local root="$1"
@@ -73,6 +68,9 @@ version_from_package_json() {
     fi
   fi
 }
+
+DIR="$(get_script_dir)"
+SEMVER="$DIR/../node_modules/sh-semver/semver.sh"
 
 if should_find_in_package_json; then
   PACKAGE_JSON_PATH=$(find_package_json_path "$PWD")


### PR DESCRIPTION
The current method for resolving the script directory only works if the script is executed directly, ie not through a symlink. Homebrew installs symlink to the `bin`, which means resolving the relative path is relative to the symlink, not the target.

We need to follow symlinks to the actual source script _before_ resolving the relative path to other files.

Fixes #21 