### PR TITLE
Switch to version hooks. Fixes #25.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+test/nodenv/
+yarn-error.log

--- a/bin/nodenv-package-json-engine
+++ b/bin/nodenv-package-json-engine
@@ -32,26 +32,13 @@ get_script_dir() {
   fi
 }
 
-find_package_json_path() {
-  local root="$1"
-  while [ -n "$root" ]; do
-    if [ -e "${root}/package.json" ]; then
-      echo "${root}/package.json"
-      exit
-    fi
-    root="${root%/*}"
-  done
-}
-
+# Give local version precedence
 should_find_in_package_json() {
   [ -z "$(nodenv local 2>/dev/null)" ]
 }
 
-version_from_package_json() {
-  local version_regex='"node":[ \t]*"([^"]*)"'
-  [[ $(cat "$PACKAGE_JSON_PATH") =~ $version_regex ]]
-  local version_expression="${BASH_REMATCH[1]}"
-
+find_installed_verion_matching_expression() {
+  local version_expression="$1"
   local -a installed_versions
   if [[ -n "$version_expression" ]] ; then
     while IFS= read -r v; do
@@ -73,9 +60,9 @@ DIR="$(get_script_dir)"
 SEMVER="$DIR/../node_modules/sh-semver/semver.sh"
 
 if should_find_in_package_json; then
-  PACKAGE_JSON_PATH=$(find_package_json_path "$PWD")
+  PACKAGE_JSON_ENGINES_EXPRESSION=$(nodenv-package-json-extract-expression)
 
-  if [ -e "$PACKAGE_JSON_PATH" ]; then
-    version_from_package_json
+  if [[ -n "$PACKAGE_JSON_ENGINES_EXPRESSION" ]]; then
+    find_installed_verion_matching_expression "$PACKAGE_JSON_ENGINES_EXPRESSION"
   fi
 fi

--- a/bin/nodenv-package-json-extract-expression
+++ b/bin/nodenv-package-json-extract-expression
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Finds the nearest package.json walking up parent dirs (npm semantics)
+# Prints the engines expression from that file.
+# Prints nothing if no file found, or file does not declare engines.
+
+# echo "BOOM $PACKAGE_JSON_PATH" >&2
+
+find_package_json_path() {
+  local root="$1"
+  while [ -n "$root" ]; do
+    if [ -e "${root}/package.json" ]; then
+      echo "${root}/package.json"
+      exit
+    fi
+    root="${root%/*}"
+  done
+}
+
+extract_version_from_package_json() {
+  local package_json_path="$1"
+  local version_regex='"node":[ \t]*"([^"]*)"'
+  [[ $(cat "$package_json_path") =~ $version_regex ]]
+  echo "${BASH_REMATCH[1]}"
+}
+
+PACKAGE_JSON_PATH=$(find_package_json_path "$PWD")
+
+if [ -e "$PACKAGE_JSON_PATH" ]; then
+  extract_version_from_package_json "$PACKAGE_JSON_PATH"
+fi

--- a/etc/nodenv.d/version-name/package-json-engine.bash
+++ b/etc/nodenv.d/version-name/package-json-engine.bash
@@ -2,5 +2,5 @@ if ! NODENV_PACKAGE_JSON_VERSION=$(nodenv-package-json-engine); then
   echo "package-json-engine: no version satisfying \`$NODENV_PACKAGE_JSON_VERSION' installed" >&2
   exit 1
 elif [ -n "$NODENV_PACKAGE_JSON_VERSION" ]; then
-  NODENV_COMMAND_PATH="${NODENV_ROOT}/versions/${NODENV_PACKAGE_JSON_VERSION}/bin/${NODENV_COMMAND}"
+  NODENV_VERSION="${NODENV_PACKAGE_JSON_VERSION}"
 fi

--- a/etc/nodenv.d/version-origin/package-json-engine.bash
+++ b/etc/nodenv.d/version-origin/package-json-engine.bash
@@ -1,0 +1,4 @@
+ENGINES_EXPRESSION=$(nodenv-package-json-extract-expression);
+if [ -n "$ENGINES_EXPRESSION" ]; then
+  NODENV_VERSION_ORIGIN="package-json-engine matching $ENGINES_EXPRESSION"
+fi


### PR DESCRIPTION
Using `version-name` and `version-origin` instead of the `which`
supports more nodenv commands, includeing `nodenv version`.

Full explanations of hooks here:
https://github.com/rbenv/rbenv/wiki/Authoring-plugins#rbenv-hooks