### PR TITLE
Use JSON.sh to parse package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,3 @@ node_js: node
 script:
   - npm run lint
   - npm test
-# from https://github.com/koalaman/shellcheck#travis-ci-setup
-addons:
-  apt:
-    sources:
-    - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-    - shellcheck

--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -6,6 +6,9 @@
 # test the installed versions against that range and print the
 # greatest matching version.
 
+# Vendored scripts:
+JSON_SH="$(plugin_root)/node_modules/JSON.sh/JSON.sh"
+SEMVER="$(plugin_root)/node_modules/sh-semver/semver.sh"
 
 # Exits non-zero if this plugin should yield precedence
 # Gives precedence to local and shell versions.
@@ -32,8 +35,8 @@ find_package_json_path() {
 
 extract_version_from_package_json() {
   package_json_path="$1"
-  version_regex='"node":[ \t]*"([^"]*)"'
-  [[ $(cat "$package_json_path") =~ $version_regex ]]
+  version_regex='\["engines","node"\][[:space:]]*"([^"]*)"'
+  [[ $("$JSON_SH" -b -n < "$package_json_path") =~ $version_regex ]]
   echo "${BASH_REMATCH[1]}"
 }
 
@@ -48,8 +51,6 @@ find_installed_version_matching_expression() {
     | tail -n 1)
   echo "$version"
 }
-
-SEMVER="$(plugin_root)/node_modules/sh-semver/semver.sh"
 
 get_version_respecting_precedence() {
   if ! package_json_has_precedence; then return; fi

--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -37,7 +37,7 @@ extract_version_from_package_json() {
   echo "${BASH_REMATCH[1]}"
 }
 
-find_installed_verion_matching_expression() {
+find_installed_version_matching_expression() {
   version_expression="$1"
   local -a installed_versions
   while IFS= read -r v; do
@@ -63,7 +63,7 @@ get_version_respecting_precedence() {
   if [ -z "$version_expression" ]; then return; fi
 
   version=$(
-    find_installed_verion_matching_expression "$version_expression"
+    find_installed_version_matching_expression "$version_expression"
   )
   if [ -z "$version" ]; then return 1; fi
   echo "$version"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "brew-publish": "^2.0.0"
   },
   "dependencies": {
-    "sh-semver": "^1.0.0"
+    "sh-semver": "^1.0.0",
+    "JSON.sh": "~0.3.3"
   }
 }

--- a/test/nodenv-package-json-engine.bats
+++ b/test/nodenv-package-json-engine.bats
@@ -85,3 +85,9 @@ load test_helper
   run nodenv version-name
   assert_success '5.0.0'
 }
+
+@test 'Does not match babel preset env settings' {
+  cd_into_babel_env_package
+  run nodenv version-name
+  assert_success 'system'
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -58,6 +58,21 @@ cd_into_package() {
   echo "$packageJson" > "$EXAMPLE_PACKAGE_DIR/package.json"
 }
 
+cd_into_babel_env_package() {
+  local packageJson="{
+    \"presets\": [
+      [\"env\", {
+        \"targets\": {
+          \"node\": \"current\"
+        }
+      }]
+    ]
+  }"
+  mkdir -p "$EXAMPLE_PACKAGE_DIR"
+  cd "$EXAMPLE_PACKAGE_DIR"
+  echo "$packageJson" > "$EXAMPLE_PACKAGE_DIR/package.json"
+}
+
 # Creates fake version directory
 create_version() {
   d="$NODENV_ROOT/versions/$1/bin"


### PR DESCRIPTION
This replaces a regex that could match babel-preset-env settings.

Fixes nodenv/nodenv-package-json-engine#31

Also, a couple minor tweaks:
- Fixed a typo
- Moved constants for vendored scripts to the top like `import`s