### PR TITLE
Cleanup from JSON.sh integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ To run tests, install [bats](https://github.com/sstephenson/bats) and [nodenv](h
 Nodenv plugin hooks integration and tests heavily inspired by [rbenv-bundler-ruby-version](https://github.com/aripollak/rbenv-bundler-ruby-version).
 
 Shell semver range support provided by [sh-semver](https://github.com/qzb/sh-semver).
+
+`package.json` parsing provided by [JSON.sh](https://github.com/dominictarr/JSON.sh).

--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -36,6 +36,7 @@ find_package_json_path() {
 extract_version_from_package_json() {
   package_json_path="$1"
   version_regex='\["engines","node"\][[:space:]]*"([^"]*)"'
+  # -b -n gives minimal output - see https://github.com/dominictarr/JSON.sh#options
   [[ $("$JSON_SH" -b -n < "$package_json_path") =~ $version_regex ]]
   echo "${BASH_REMATCH[1]}"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -49,15 +49,16 @@ assert_success() {
 
 # cd_into_package nodeVersion [extraArgs]
 cd_into_package() {
-  local version="$1"
-  local packageJson="{
-    \"engines\": {
-      \"node\": \"${version}\"
-    }
-  }"
   mkdir -p "$EXAMPLE_PACKAGE_DIR"
   cd "$EXAMPLE_PACKAGE_DIR" || return 1
-  echo "$packageJson" > "$EXAMPLE_PACKAGE_DIR/package.json"
+  local version="$1"
+  cat << JSON > package.json
+{
+  "engines": {
+    "node": "$version"
+  }
+}
+JSON
 }
 
 cd_into_babel_env_package() {


### PR DESCRIPTION
- Use a heredoc in `cd_into_package` test helper
- Give credit to JSON.sh
- Link to JSON.sh documentation for options

See https://github.com/nodenv/nodenv-package-json-engine/pull/32

:)