### PR TITLE
Handle non-semver node versions

### DIFF
--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -46,7 +46,7 @@ find_installed_version_matching_expression() {
   local -a installed_versions
   while IFS= read -r v; do
     installed_versions+=( "$v" )
-  done < <(nodenv versions --bare --skip-aliases)
+  done < <(nodenv versions --bare --skip-aliases | grep -e '^[[:digit:]]')
 
   version=$("$SEMVER" -r "$version_expression" "${installed_versions[@]}" \
     | tail -n 1)


### PR DESCRIPTION
sh-semver emits warnings when non-semver strings are passed to it.
So we should filter out and ignore any node versions that don't at least
start with a number.

This could be a lot smarter, and currently only works because node
versions omit the implicit 'node-' prefix.

fixes #37 