### PR TITLE
Switch assertion libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,13 @@
       "dev": true
     },
     "bats-assert": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-1.1.1.tgz",
-      "integrity": "sha1-E+8EWuvEJZSWyKG3/x7otPguWM0=",
+      "version": "github:ztombol/bats-assert#9f88b4207da750093baabc4e3f41bf68f0dd3630",
+      "from": "github:ztombol/bats-assert",
+      "dev": true
+    },
+    "bats-support": {
+      "version": "github:ztombol/bats-support#004e707638eedd62e0481e8cdc9223ad471f12ee",
+      "from": "github:ztombol/bats-support",
       "dev": true
     },
     "brew-publish": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,13 @@
       "dev": true
     },
     "bats-assert": {
-      "version": "github:ztombol/bats-assert#9f88b4207da750093baabc4e3f41bf68f0dd3630",
-      "from": "github:ztombol/bats-assert",
+      "version": "github:jasonkarns/bats-assert-1#9f88b4207da750093baabc4e3f41bf68f0dd3630",
+      "from": "github:jasonkarns/bats-assert-1",
       "dev": true
     },
     "bats-support": {
-      "version": "github:ztombol/bats-support#004e707638eedd62e0481e8cdc9223ad471f12ee",
-      "from": "github:ztombol/bats-support",
+      "version": "github:jasonkarns/bats-support#004e707638eedd62e0481e8cdc9223ad471f12ee",
+      "from": "github:jasonkarns/bats-support",
       "dev": true
     },
     "brew-publish": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "devDependencies": {
     "@nodenv/nodenv": "^1.1.2",
     "bats": "^1.1.0",
-    "bats-assert": "ztombol/bats-assert",
-    "bats-support": "ztombol/bats-support",
+    "bats-assert": "jasonkarns/bats-assert-1",
+    "bats-support": "jasonkarns/bats-support",
     "brew-publish": "^2.3.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "devDependencies": {
     "@nodenv/nodenv": "^1.1.2",
     "bats": "^1.1.0",
-    "bats-assert": "^1.1.1",
+    "bats-assert": "ztombol/bats-assert",
+    "bats-support": "ztombol/bats-support",
     "brew-publish": "^2.3.1"
   },
   "dependencies": {

--- a/test/nodenv-package-json-engine.bats
+++ b/test/nodenv-package-json-engine.bats
@@ -6,14 +6,16 @@ load test_helper
   in_package_for_engine 4.2.1
 
   run nodenv version
-  assert_success '4.2.1 (set by package-json-engine matching 4.2.1)'
+  assert_success
+  assert_output '4.2.1 (set by package-json-engine matching 4.2.1)'
 }
 
 @test 'Prefers the greatest installed version matching a range' {
   in_package_for_engine '^4.0.0'
 
   run nodenv version
-  assert_success '4.2.1 (set by package-json-engine matching ^4.0.0)'
+  assert_success
+  assert_output '4.2.1 (set by package-json-engine matching ^4.0.0)'
 }
 
 @test 'Ignores non-matching installed versions' {
@@ -21,8 +23,11 @@ load test_helper
 
   run nodenv version
   # note the command completes successfully
-  assert_success "package-json-engine: version satisfying \`^1.0.0' not installed
- (set by package-json-engine matching ^1.0.0)"
+  assert_success
+  assert_output <<-MSG
+package-json-engine: version satisfying \`^1.0.0' not installed
+ (set by package-json-engine matching ^1.0.0)
+MSG
 }
 
 @test 'Prefers nodenv-local over package.json' {
@@ -30,14 +35,16 @@ load test_helper
   nodenv local 5.0.0
 
   run nodenv version
-  assert_success "5.0.0 (set by $PWD/.node-version)"
+  assert_success
+  assert_output "5.0.0 (set by $PWD/.node-version)"
 }
 
 @test 'Prefers nodenv-shell over package.json' {
   in_package_for_engine 4.2.1
 
   NODENV_VERSION=5.0.0 run nodenv version
-  assert_success "5.0.0 (set by NODENV_VERSION environment variable)"
+  assert_success
+  assert_output "5.0.0 (set by NODENV_VERSION environment variable)"
 }
 
 @test 'Prefers package.json over nodenv-global' {
@@ -45,7 +52,8 @@ load test_helper
   nodenv global 5.0.0
 
   run nodenv version-name
-  assert_success '4.2.1'
+  assert_success
+  assert_output '4.2.1'
 }
 
 @test 'Is not confused by nodenv-shell shadowing nodenv-global' {
@@ -53,7 +61,8 @@ load test_helper
   nodenv global 5.0.0
 
   NODENV_VERSION=5.0.0 run nodenv version
-  assert_success "5.0.0 (set by NODENV_VERSION environment variable)"
+  assert_success
+  assert_output "5.0.0 (set by NODENV_VERSION environment variable)"
 }
 
 @test 'Does not match arbitrary "node" key in package.json' {
@@ -61,7 +70,8 @@ load test_helper
 
   run nodenv version-name
 
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 }
 
 @test 'Handles missing package.json' {
@@ -69,7 +79,8 @@ load test_helper
 
   run nodenv version-name
 
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 }
 
 @test 'Does not fail with unreadable package.json' {
@@ -79,7 +90,8 @@ load test_helper
 
   run nodenv version-name
 
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 }
 
 @test 'Does not fail with non-file package.json' {
@@ -88,7 +100,8 @@ load test_helper
 
   run nodenv version-name
 
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 }
 
 @test 'Does not fail with empty or malformed package.json' {
@@ -97,17 +110,20 @@ load test_helper
   # empty
   touch package.json
   run nodenv version-name
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 
   # non json
   echo "foo" > package.json
   run nodenv version-name
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 
   # malformed
   echo "{" > package.json
   run nodenv version-name
-  assert_success 'system'
+  assert_success
+  assert_output 'system'
 }
 
 @test 'Handles multiple occurrences of "node" key' {
@@ -128,5 +144,6 @@ load test_helper
 JSON
 
   run nodenv version-name
-  assert_success '4.2.1'
+  assert_success
+  assert_output '4.2.1'
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
-load ../node_modules/bats-assert/all
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
 
 setup() {
   # common nodenv setup


### PR DESCRIPTION
Attempting to unify my repos on ztombol's bats helper libs since they have much nicer output and a more consistent interface.