### PR TITLE
Improve performance

### DIFF
--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -50,9 +50,20 @@ find_installed_version_matching_expression() {
     installed_versions+=( "$v" )
   done < <(nodenv versions --bare --skip-aliases | grep -e '^[[:digit:]]')
 
-  version=$("$SEMVER" -r "$version_expression" "${installed_versions[@]}" \
-    | tail -n 1)
-  echo "$version"
+  local fast_guess
+  fast_guess=$("$SEMVER" -r "$version_expression" "${installed_versions[@]:${#installed_versions[@]}-1}" | tail -n 1)
+
+  # Most #engine version specs just specify a baseline version,
+  # which means most likely, the highest installed version will satisfy
+  # This does a first pass with just that single version in hopes it satisfies.
+  # If so, we can avoid the cost of sh-semver sorting and validating across
+  # all the installed versions.
+  if [ -n "$fast_guess" ]; then
+    echo "$fast_guess"
+    return
+  fi
+
+  "$SEMVER" -r "$version_expression" "${installed_versions[@]}" | tail -n 1
 }
 
 get_version_respecting_precedence() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,12 @@
     },
     "bats-assert": {
       "version": "github:jasonkarns/bats-assert-1#8200039faf9790c05d9865490c97a0e101b9c80f",
+      "from": "github:jasonkarns/bats-assert-1",
       "dev": true
     },
     "bats-support": {
       "version": "github:jasonkarns/bats-support#004e707638eedd62e0481e8cdc9223ad471f12ee",
+      "from": "github:jasonkarns/bats-support",
       "dev": true
     },
     "brew-publish": {
@@ -36,9 +38,8 @@
       "dev": true
     },
     "sh-semver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sh-semver/-/sh-semver-1.0.0.tgz",
-      "integrity": "sha1-aIBsvAKjJEXkLsC0y3E8FP05ynk="
+      "version": "github:qzb/sh-semver#a962f9d2f3d26b2da3d4116661cc207fe50bb99c",
+      "from": "github:qzb/sh-semver"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "brew-publish": "^2.3.1"
   },
   "dependencies": {
-    "sh-semver": "^1.0.0",
+    "sh-semver": "qzb/sh-semver",
     "JSON.sh": "~0.3.3"
   }
 }


### PR DESCRIPTION
Almost the entirety of the perf hit in this plugin is due to sh-semver.
And its performance is a function of the number of installed versions
checked against the version spec rule.
So to improve perf in the common case, we only check the highest
installed version against the version spec.
If it satisfies, we can exit early and bypass the expensive sh-semver
call. Otherwise, we still incur that hit.

Brought my usage from ~3s to ~.100s (for about 24 installed versions)

closes #45 