### PR TITLE
Improve version-origin messaging

### DIFF
--- a/etc/nodenv.d/version-name/package-json-engine.bash
+++ b/etc/nodenv.d/version-name/package-json-engine.bash
@@ -2,7 +2,7 @@
 source "$(plugin_root)/libexec/nodenv-package-json-engine"
 
 if ! NODENV_PACKAGE_JSON_VERSION=$(get_version_respecting_precedence); then
-  echo "package-json-engine: version satisfying \`$(get_expression_respecting_precedence)' not installed" >&2
+  echo "package-json-engine: version satisfying \`$(get_expression_respecting_precedence)' is not installed" >&2
   exit 1
 elif [ -n "$NODENV_PACKAGE_JSON_VERSION" ]; then
   export NODENV_VERSION="${NODENV_PACKAGE_JSON_VERSION}"

--- a/etc/nodenv.d/version-name/package-json-engine.bash
+++ b/etc/nodenv.d/version-name/package-json-engine.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # shellcheck source=libexec/nodenv-package-json-engine
 source "$(plugin_root)/libexec/nodenv-package-json-engine"
 

--- a/etc/nodenv.d/version-origin/package-json-engine.bash
+++ b/etc/nodenv.d/version-origin/package-json-engine.bash
@@ -5,5 +5,6 @@ source "$(plugin_root)/libexec/nodenv-package-json-engine"
 
 ENGINES_EXPRESSION=$(get_expression_respecting_precedence);
 if [ -n "$ENGINES_EXPRESSION" ]; then
-  export NODENV_VERSION_ORIGIN="package-json-engine matching $ENGINES_EXPRESSION"
+  NODENV_VERSION_ORIGIN="$(package_json_path)#engines.node"
+  export NODENV_VERSION_ORIGIN
 fi

--- a/etc/nodenv.d/version-origin/package-json-engine.bash
+++ b/etc/nodenv.d/version-origin/package-json-engine.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # shellcheck source=libexec/nodenv-package-json-engine
 source "$(plugin_root)/libexec/nodenv-package-json-engine"
 

--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -62,11 +62,15 @@ find_installed_version_matching_expression() {
   "$SEMVER" -r "$version_expression" "${installed_versions[@]}" | tail -n 1
 }
 
+package_json_path() {
+  path=$(find_package_json_path "$PWD")
+  [ -r "$path" ] && [ -f "$path" ] && echo "$path"
+}
+
 get_version_respecting_precedence() {
   if ! package_json_has_precedence; then return; fi
 
-  package_json_path=$(find_package_json_path "$PWD")
-  if [ ! -e "$package_json_path" ]; then return; fi
+  package_json_path=$(package_json_path) || return 0
 
   version_expression=$(
     extract_version_from_package_json "$package_json_path"
@@ -83,8 +87,7 @@ get_version_respecting_precedence() {
 get_expression_respecting_precedence() {
   if ! package_json_has_precedence; then return; fi
 
-  package_json_path=$(find_package_json_path "$PWD")
-  if [ ! -e "$package_json_path" ]; then return; fi
+  package_json_path=$(package_json_path) || return 0
 
   version_expression=$(
     extract_version_from_package_json "$package_json_path"

--- a/libexec/nodenv-package-json-engine
+++ b/libexec/nodenv-package-json-engine
@@ -14,12 +14,8 @@ SEMVER="$(plugin_root)/node_modules/sh-semver/semver.sh"
 # Gives precedence to local and shell versions.
 # Takes precedence over global version.
 package_json_has_precedence() {
-  if [[ ( -z "$(nodenv local 2>/dev/null)" )
-  && ( -z "$(nodenv sh-shell 2>/dev/null)" ) ]]; then
-    return;
-  else
-    return 1;
-  fi
+  [ -z "$(nodenv local 2>/dev/null)" ] &&
+  [ -z "$(nodenv sh-shell 2>/dev/null)" ]
 }
 
 find_package_json_path() {

--- a/test/nodenv-package-json-engine.bats
+++ b/test/nodenv-package-json-engine.bats
@@ -7,7 +7,7 @@ load test_helper
 
   run nodenv version
   assert_success
-  assert_output '4.2.1 => node-x.y.z (set by package-json-engine matching 4.2.1)'
+  assert_output "4.2.1 => node-x.y.z (set by $PWD/package.json#engines.node)"
 }
 
 @test 'Prefers the greatest installed version matching a range' {
@@ -15,7 +15,7 @@ load test_helper
 
   run nodenv version
   assert_success
-  assert_output '4.2.1 => node-x.y.z (set by package-json-engine matching ^4.0.0)'
+  assert_output "4.2.1 => node-x.y.z (set by $PWD/package.json#engines.node)"
 }
 
 @test 'Ignores non-matching installed versions' {

--- a/test/nodenv-package-json-engine.bats
+++ b/test/nodenv-package-json-engine.bats
@@ -24,7 +24,7 @@ load test_helper
   run nodenv version
   assert_failure
   assert_output - <<-MSG
-package-json-engine: version satisfying \`^1.0.0' not installed
+package-json-engine: version satisfying \`^1.0.0' is not installed
 MSG
 }
 


### PR DESCRIPTION
nodenv-version does not print the contents of .node-version nor 
NODENV_VERSION files/variables. Nor does it indicate which command/plugin
is setting the value.

Instead, it prints the path to the file or the env var name. Users can then
inspect the file/variable themselves.

Similarly, we now print the path to the exact package.json file used, and
the #engines.node property that sets the value. We no longer print the 
value of that property.

This makes the output more consistent with nodenv itself.