### PR TITLE
Add shellcheck as devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,12 @@
     "sh-semver": {
       "version": "github:qzb/sh-semver#a962f9d2f3d26b2da3d4116661cc207fe50bb99c",
       "from": "github:qzb/sh-semver"
+    },
+    "shellcheck": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shellcheck/-/shellcheck-0.3.0.tgz",
+      "integrity": "sha512-6I/5hSgP433kUNYL0HLNm3wu/w89Em5mYqfPEut/NIfyd9Wv8R3Y+Uupu1iTdzxwomMqJIR+DzH9NIGskpkRoA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "bats": "^1.1.0",
     "bats-assert": "jasonkarns/bats-assert-1",
     "bats-support": "jasonkarns/bats-support",
-    "brew-publish": "^2.3.1"
+    "brew-publish": "^2.3.1",
+    "shellcheck": "^0.3.0"
   },
   "dependencies": {
     "sh-semver": "qzb/sh-semver",


### PR DESCRIPTION
Travis has it installed by default, but it's an old version. Using the
npm package ensures we get the latest version (and also that it's
installed for maintainers).